### PR TITLE
Add configurable start angle and arc length per gauge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-08-03
+
+### Added
+- 📐 **Arc geometry per gauge** — configurable from the visual editor (new *Arc Geometry* section)
+  - `start_angle` (degrees, default `0`): offsets the starting point of a gauge. `0` = top
+    (12 o'clock), positive values rotate clockwise
+  - `arc_length` (degrees, default `360`): angular span of a gauge. `360` = full circle,
+    `270` = car-dashboard style, `180` = half circle. Values above 360 are clamped
+  - Both options are independent for the inner and the outer gauge
+  - LEDs, markers and zones all follow the arc, so they stay aligned with their gauge
+  - On a partial arc, both ends carry a LED (`min` exactly at the start, `max` exactly at the end);
+    on a full circle the LEDs keep their previous distribution
+  - In bidirectional mode on a partial arc, the reference point is placed proportionally inside
+    the arc so both sides stay visible (full-circle behaviour is unchanged)
+
+### Fixed
+- 🐛 Calling `setConfig()` twice on the same card (live preview in the editor) threw
+  `NotSupportedError: Shadow root cannot be created on a host which already hosts one`
+- 🐛 The card no longer throws when `hass` is set before `setConfig()`
+
+### Changed
+- ✅ **Home Assistant compliance of the visual editor**
+  - `config-changed` and `hass-more-info` are now real `CustomEvent`s with a `detail` payload
+    instead of a plain `Event` with a property attached to it
+  - The editor now preserves configuration keys it does not manage (`view_layout`,
+    `grid_options`, `visibility`, per-gauge `tap_action`, ...) instead of dropping them on
+    every change
+  - Clearing an optional field in the editor now removes the key from the YAML instead of
+    leaving the previous value behind
+  - All configuration values are HTML-escaped before being injected in the editor markup, so a
+    quote in a card name, a font family or a marker label can no longer break the form
+
 ## [1.3.0] - 2026-03-20
 
 ### Major Changes

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Perfect for comparing indoor/outdoor temperatures, displaying temperature and hu
 - Separate configuration for each gauge
 - Configurable primary value display (choose which value shows large)
 - Adjustable gauge spacing
+- Adjustable start angle and arc length per gauge (full circle, 270°, half circle...)
 - bidirectional for negative values
 
 **Advanced Shadow System**
@@ -190,7 +191,7 @@ The `bidirectional` option enables support for displaying negative values with v
 
 - **Positive values** display clockwise (right side) from the top (12 o'clock position)
 - **Negative values** display counter-clockwise (left side) from the top
-- **Zero point** is always at the top of the gauge
+- **Zero point** is at the start of the gauge, i.e. the top by default (see `start_angle`)
 - **LED allocation** is proportional to the range on each side of zero
 
 This is perfect for:
@@ -227,6 +228,8 @@ gauges:
 |--------|------|--------|-------------|
 | `leds_count` | number | 100 | Number of LEDs on the circle |
 | `led_size` | number | 8 (outer) / 6 (inner) | LED size in pixels |
+| `start_angle` | number | 0 | Offset of the gauge starting point, in degrees (see below) |
+| `arc_length` | number | 360 | Angular span of the gauge, in degrees (see below) |
 | `hide_inactive_leds` | boolean | false | Hide inactive LEDs |
 | `value_font_size` | string | '24px' | Font size for value (e.g. '30px') |
 | `value_font_weight` | string | 'bold' | Font weight for value |
@@ -524,6 +527,61 @@ inner_gauge_radius: 100     # Almost touching
 ```
 
 **Note:** The larger `inner_gauge_radius` is, the **closer** the inner gauge gets to the outer gauge.
+
+### Arc Geometry (Start Angle & Arc Length)
+
+Each gauge can be rotated and shortened independently with two options, both configurable
+from the visual editor (section **Arc Geometry**):
+
+| Option | Type | Default | Description |
+|--------|------|--------|-------------|
+| `start_angle` | number | 0 | Where the gauge starts. `0` = top (12 o'clock), positive values rotate clockwise. Accepts -360 to 360 |
+| `arc_length` | number | 360 | How much of the circle the gauge covers. `360` = full circle, `180` = half circle. Values above 360 are clamped |
+
+```yaml
+# Classic car-dashboard look: 270° arc opening at the bottom
+gauges:
+  - entity: sensor.temp_inside
+    start_angle: -135     # start at the lower-left
+    arc_length: 270       # end at the lower-right
+  - entity: sensor.temp_outside
+    start_angle: -135
+    arc_length: 270
+```
+
+```yaml
+# Half circle (speedometer style), inner and outer aligned
+gauges:
+  - entity: sensor.power_now
+    start_angle: -90      # start on the left
+    arc_length: 180       # end on the right
+  - entity: sensor.power_max
+    start_angle: -90
+    arc_length: 180
+```
+
+```yaml
+# Rotate a full circle so that the seam (min/max) sits at the bottom
+gauges:
+  - entity: sensor.humidity
+    start_angle: 180
+  - entity: sensor.temperature
+    start_angle: 180
+```
+
+**How it behaves:**
+
+- On a **full circle** (`arc_length: 360`), the first and last LED would overlap, so LEDs are
+  spread over the circle without a LED on the closing point. On a **partial arc**, both ends of
+  the arc carry a LED, so `min` sits exactly at the start of the arc and `max` exactly at its end.
+- **Markers and zones follow the arc**: they are placed with the same start angle and span as
+  the LEDs, so they stay aligned with their gauge.
+- The two gauges are independent: you can keep the outer one a full circle and make the inner
+  one a 180° arc.
+- In **bidirectional mode**, the reference point (zero) stays at the start of the arc on a full
+  circle — unchanged behaviour. On a partial arc there is nothing to wrap around, so the
+  reference point is placed proportionally inside the arc: `min` sits at the start, `max` at the
+  end, and the LEDs light up from the reference point towards either end.
 
 ## Usage Examples
 

--- a/dual-gauge-card-editor.js
+++ b/dual-gauge-card-editor.js
@@ -1,6 +1,6 @@
 /**
  * Dual Gauge Card Editor - Visual Configuration Editor
- * Version: 1.3.0
+ * Version: 1.4.0
  * 
  * This file is dynamically loaded by dual-gauge-card.js
  * when the user opens the visual editor.
@@ -76,7 +76,13 @@ const translations = {
     ledSize: 'LED Size (px)',
     theme: 'Theme',
     animationDuration: 'Animation Duration (ms)',
-    
+
+    // Arc geometry
+    arcGeometry: 'Arc Geometry',
+    startAngle: 'Start Angle (°)',
+    arcLength: 'Arc Length (°)',
+    arcGeometryHelp: 'Start angle offsets the beginning of the gauge: 0° = top (12 o\'clock), positive values rotate clockwise. Arc length is the angular span of the gauge: 360° = full circle, 180° = half circle.',
+
     // Gauge options
     bidirectionalMode: 'Bidirectional Mode',
     hideInactiveLeds: 'Hide Inactive LEDs',
@@ -130,6 +136,27 @@ const translations = {
     selectEntity: 'Select an entity'
   }
 };
+
+// ============================================================================
+// UTILITIES
+// ============================================================================
+
+/**
+ * Escape a value before interpolating it into the editor markup.
+ * The editor is built with innerHTML, so a quote in a name, a font family or a marker
+ * label would otherwise break out of its attribute.
+ * @param {*} value - Value coming from the card configuration
+ * @returns {string} HTML-safe string
+ */
+function esc(value) {
+  if (value === undefined || value === null) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 
 // ============================================================================
 // VISUAL EDITOR CLASS
@@ -269,6 +296,8 @@ class DualGaugeCardEditor extends HTMLElement {
       setValue(`gauge${i}_decimals`, gauge.decimals ?? 1);
       setValue(`gauge${i}_leds_count`, gauge.leds_count || (i === 0 ? 80 : 100));
       setValue(`gauge${i}_led_size`, gauge.led_size || (i === 0 ? 6 : 8));
+      setValue(`gauge${i}_start_angle`, gauge.start_angle !== undefined ? gauge.start_angle : 0);
+      setValue(`gauge${i}_arc_length`, gauge.arc_length !== undefined ? gauge.arc_length : 360);
       setValue(`gauge${i}_markers_radius`, gauge.markers_radius !== undefined ? gauge.markers_radius : '');
       setChecked(`gauge${i}_markers_inside`, gauge.markers_inside !== false);
       setValue(`gauge${i}_theme`, gauge.theme || 'default');
@@ -328,14 +357,21 @@ class DualGaugeCardEditor extends HTMLElement {
   _updateEntitySelects() {
     // Update entity select options when hass becomes available
     if (!this._hass || !this._hass.states) return;
-    
+
     for (let i = 0; i < 2; i++) {
       const select = this.shadowRoot.getElementById(`gauge${i}_entity`);
-      if (select) {
-        const currentValue = this._config?.gauges?.[i]?.entity || '';
-        const optionsHtml = this._renderEntityOptions(currentValue);
-        select.innerHTML = optionsHtml;
-      }
+      if (!select) continue;
+
+      const currentValue = this._config?.gauges?.[i]?.entity || '';
+
+      // Home Assistant pushes a new hass object on every state change. Rebuilding the whole
+      // entity list each time would freeze the editor, so only rebuild when the list of
+      // entities or the selection actually changed.
+      const signature = `${Object.keys(this._hass.states).length}|${currentValue}`;
+      if (select.dataset.signature === signature) continue;
+
+      select.innerHTML = this._renderEntityOptions(currentValue);
+      select.dataset.signature = signature;
     }
   }
 
@@ -553,22 +589,22 @@ class DualGaugeCardEditor extends HTMLElement {
         <div class="row">
           <div class="field full">
             <label>${this._t('cardName')}</label>
-            <input type="text" id="name" value="${config.name || ''}" placeholder="Dual Gauge">
+            <input type="text" id="name" value="${esc(config.name || '')}" placeholder="Dual Gauge">
           </div>
         </div>
 
         <div class="row">
           <div class="field">
             <label>${this._t('outerGaugeSize')}</label>
-            <input type="number" id="gauge_size" value="${config.gauge_size || 200}" min="100" max="400">
+            <input type="number" id="gauge_size" value="${esc(config.gauge_size || 200)}" min="100" max="400">
           </div>
           <div class="field">
             <label>${this._t('innerGaugeSize')}</label>
-            <input type="number" id="inner_gauge_size" value="${config.inner_gauge_size || 130}" min="80" max="300">
+            <input type="number" id="inner_gauge_size" value="${esc(config.inner_gauge_size || 130)}" min="80" max="300">
           </div>
           <div class="field">
             <label>${this._t('innerGaugeRadius')}</label>
-            <input type="number" id="inner_gauge_radius" value="${config.inner_gauge_radius || 65}" min="40" max="150">
+            <input type="number" id="inner_gauge_radius" value="${esc(config.inner_gauge_radius || 65)}" min="40" max="150">
           </div>
         </div>
 
@@ -616,7 +652,7 @@ class DualGaugeCardEditor extends HTMLElement {
           </div>
           <div class="field">
             <label>${this._t('updateInterval')}</label>
-            <input type="number" id="update_interval" value="${config.update_interval || 1000}" min="100" max="10000" step="100">
+            <input type="number" id="update_interval" value="${esc(config.update_interval || 1000)}" min="100" max="10000" step="100">
           </div>
         </div>
       </div>
@@ -650,22 +686,22 @@ class DualGaugeCardEditor extends HTMLElement {
           <div class="field">
             <label>${this._t('cardBackground')}</label>
             <div class="color-row">
-              <input type="color" id="custom_background" value="${config.custom_background || '#222222'}" data-field="color">
-              <input type="text" id="custom_background_text" value="${config.custom_background || '#222222'}" placeholder="#222222" data-field="color_text">
+              <input type="color" id="custom_background" value="${esc(config.custom_background || '#222222')}" data-field="color">
+              <input type="text" id="custom_background_text" value="${esc(config.custom_background || '#222222')}" placeholder="#222222" data-field="color_text">
             </div>
           </div>
           <div class="field">
             <label>${this._t('gaugeBackground')}</label>
             <div class="color-row">
-              <input type="color" id="custom_gauge_background" value="${config.custom_gauge_background?.startsWith('#') ? config.custom_gauge_background : '#444444'}" data-field="color">
-              <input type="text" id="custom_gauge_background_text" value="${config.custom_gauge_background || '#444444'}" placeholder="#444444 or gradient" data-field="color_text">
+              <input type="color" id="custom_gauge_background" value="${esc(config.custom_gauge_background?.startsWith('#') ? config.custom_gauge_background : '#444444')}" data-field="color">
+              <input type="text" id="custom_gauge_background_text" value="${esc(config.custom_gauge_background || '#444444')}" placeholder="#444444 or gradient" data-field="color_text">
             </div>
           </div>
           <div class="field">
             <label>${this._t('centerBackground')}</label>
             <div class="color-row">
-              <input type="color" id="custom_center_background" value="${config.custom_center_background?.startsWith('#') ? config.custom_center_background : '#333333'}" data-field="color">
-              <input type="text" id="custom_center_background_text" value="${config.custom_center_background || '#333333'}" placeholder="#333333 or gradient" data-field="color_text">
+              <input type="color" id="custom_center_background" value="${esc(config.custom_center_background?.startsWith('#') ? config.custom_center_background : '#333333')}" data-field="color">
+              <input type="text" id="custom_center_background_text" value="${esc(config.custom_center_background || '#333333')}" placeholder="#333333 or gradient" data-field="color_text">
             </div>
           </div>
         </div>
@@ -674,15 +710,15 @@ class DualGaugeCardEditor extends HTMLElement {
           <div class="field">
             <label>${this._t('primaryTextColor')}</label>
             <div class="color-row">
-              <input type="color" id="custom_text_color" value="${config.custom_text_color || '#ffffff'}" data-field="color">
-              <input type="text" id="custom_text_color_text" value="${config.custom_text_color || '#ffffff'}" placeholder="#ffffff" data-field="color_text">
+              <input type="color" id="custom_text_color" value="${esc(config.custom_text_color || '#ffffff')}" data-field="color">
+              <input type="text" id="custom_text_color_text" value="${esc(config.custom_text_color || '#ffffff')}" placeholder="#ffffff" data-field="color_text">
             </div>
           </div>
           <div class="field">
             <label>${this._t('secondaryTextColor')}</label>
             <div class="color-row">
-              <input type="color" id="custom_secondary_text_color" value="${config.custom_secondary_text_color || '#dddddd'}" data-field="color">
-              <input type="text" id="custom_secondary_text_color_text" value="${config.custom_secondary_text_color || '#dddddd'}" placeholder="#dddddd" data-field="color_text">
+              <input type="color" id="custom_secondary_text_color" value="${esc(config.custom_secondary_text_color || '#dddddd')}" data-field="color">
+              <input type="text" id="custom_secondary_text_color_text" value="${esc(config.custom_secondary_text_color || '#dddddd')}" placeholder="#dddddd" data-field="color_text">
             </div>
           </div>
         </div>
@@ -698,11 +734,11 @@ class DualGaugeCardEditor extends HTMLElement {
         <div class="row">
           <div class="field">
             <label>${this._t('fontSize')}</label>
-            <input type="text" id="title_font_size" value="${config.title_font_size || '16px'}" placeholder="16px">
+            <input type="text" id="title_font_size" value="${esc(config.title_font_size || '16px')}" placeholder="16px">
           </div>
           <div class="field">
             <label>${this._t('fontFamily')}</label>
-            <input type="text" id="title_font_family" value="${config.title_font_family || ''}" placeholder="inherit">
+            <input type="text" id="title_font_family" value="${esc(config.title_font_family || '')}" placeholder="inherit">
           </div>
           <div class="field">
             <label>${this._t('fontWeight')}</label>
@@ -727,13 +763,13 @@ class DualGaugeCardEditor extends HTMLElement {
           <div class="field">
             <label>${this._t('titleColor')}</label>
             <div class="color-row">
-              <input type="color" id="title_font_color" value="${config.title_font_color || '#ffffff'}" data-field="color">
-              <input type="text" id="title_font_color_text" value="${config.title_font_color || ''}" placeholder="Auto" data-field="color_text">
+              <input type="color" id="title_font_color" value="${esc(config.title_font_color || '#ffffff')}" data-field="color">
+              <input type="text" id="title_font_color_text" value="${esc(config.title_font_color || '')}" placeholder="Auto" data-field="color_text">
             </div>
           </div>
           <div class="field">
             <label>${this._t('cardBackgroundCss')}</label>
-            <input type="text" id="card_background" value="${config.card_background || ''}" placeholder="e.g. #222 or gradient">
+            <input type="text" id="card_background" value="${esc(config.card_background || '')}" placeholder="e.g. #222 or gradient">
           </div>
         </div>
       </div>
@@ -772,7 +808,7 @@ class DualGaugeCardEditor extends HTMLElement {
     const entities = Object.keys(this._hass.states).sort();
     const options = entities.map(entityId => {
       const selected = entityId === selectedEntity ? 'selected' : '';
-      return `<option value="${entityId}" ${selected}>${entityId}</option>`;
+      return `<option value="${esc(entityId)}" ${selected}>${esc(entityId)}</option>`;
     }).join('');
     
     return `<option value="">-- ${this._t('selectEntity')} --</option>${options}`;
@@ -803,30 +839,45 @@ class DualGaugeCardEditor extends HTMLElement {
         <div class="row">
           <div class="field">
             <label>${this._t('minValue')}</label>
-            <input type="number" id="gauge${index}_min" value="${gauge.min !== undefined ? gauge.min : 0}" step="any">
+            <input type="number" id="gauge${index}_min" value="${esc(gauge.min !== undefined ? gauge.min : 0)}" step="any">
           </div>
           <div class="field">
             <label>${this._t('maxValue')}</label>
-            <input type="number" id="gauge${index}_max" value="${gauge.max !== undefined ? gauge.max : 100}" step="any">
+            <input type="number" id="gauge${index}_max" value="${esc(gauge.max !== undefined ? gauge.max : 100)}" step="any">
           </div>
           <div class="field">
             <label>${this._t('unit')}</label>
-            <input type="text" id="gauge${index}_unit" value="${gauge.unit || ''}" placeholder="%">
+            <input type="text" id="gauge${index}_unit" value="${esc(gauge.unit || '')}" placeholder="%">
           </div>
         </div>
 
         <div class="row">
           <div class="field">
             <label>${this._t('decimals')}</label>
-            <input type="number" id="gauge${index}_decimals" value="${gauge.decimals !== undefined ? gauge.decimals : 1}" min="0" max="5">
+            <input type="number" id="gauge${index}_decimals" value="${esc(gauge.decimals !== undefined ? gauge.decimals : 1)}" min="0" max="5">
           </div>
           <div class="field">
             <label>${this._t('ledsCount')}</label>
-            <input type="number" id="gauge${index}_leds_count" value="${gauge.leds_count || (index === 0 ? 80 : 100)}" min="10" max="200">
+            <input type="number" id="gauge${index}_leds_count" value="${esc(gauge.leds_count || (index === 0 ? 80 : 100))}" min="10" max="200">
           </div>
           <div class="field">
             <label>${this._t('ledSize')}</label>
-            <input type="number" id="gauge${index}_led_size" value="${gauge.led_size || (index === 0 ? 6 : 8)}" min="2" max="20">
+            <input type="number" id="gauge${index}_led_size" value="${esc(gauge.led_size || (index === 0 ? 6 : 8))}" min="2" max="20">
+          </div>
+        </div>
+
+        <div class="sub-section">
+          <div class="sub-title">${this._t('arcGeometry')}</div>
+          <div class="help-text">${this._t('arcGeometryHelp')}</div>
+          <div class="row">
+            <div class="field">
+              <label>${this._t('startAngle')}</label>
+              <input type="number" id="gauge${index}_start_angle" value="${esc(gauge.start_angle !== undefined ? gauge.start_angle : 0)}" min="-360" max="360" step="1">
+            </div>
+            <div class="field">
+              <label>${this._t('arcLength')}</label>
+              <input type="number" id="gauge${index}_arc_length" value="${esc(gauge.arc_length !== undefined ? gauge.arc_length : 360)}" min="10" max="360" step="1">
+            </div>
           </div>
         </div>
 
@@ -842,7 +893,7 @@ class DualGaugeCardEditor extends HTMLElement {
           </div>
           <div class="field">
             <label>${this._t('animationDuration')}</label>
-            <input type="number" id="gauge${index}_animation_duration" value="${gauge.animation_duration || 800}" min="0" max="5000" step="100">
+            <input type="number" id="gauge${index}_animation_duration" value="${esc(gauge.animation_duration || 800)}" min="0" max="5000" step="100">
           </div>
         </div>
 
@@ -875,22 +926,22 @@ class DualGaugeCardEditor extends HTMLElement {
         <div class="row" id="gauge${index}_center_shadow_options" style="display: ${gauge.center_shadow ? 'flex' : 'none'};">
           <div class="field">
             <label>${this._t('centerShadowBlur')}</label>
-            <input type="number" id="gauge${index}_center_shadow_blur" value="${gauge.center_shadow_blur || 30}" min="0" max="100">
+            <input type="number" id="gauge${index}_center_shadow_blur" value="${esc(gauge.center_shadow_blur || 30)}" min="0" max="100">
           </div>
           <div class="field">
             <label>${this._t('centerShadowSpread')}</label>
-            <input type="number" id="gauge${index}_center_shadow_spread" value="${gauge.center_shadow_spread || 15}" min="0" max="100">
+            <input type="number" id="gauge${index}_center_shadow_spread" value="${esc(gauge.center_shadow_spread || 15)}" min="0" max="100">
           </div>
         </div>
 
         <div class="row" id="gauge${index}_outer_shadow_options" style="display: ${gauge.outer_shadow ? 'flex' : 'none'};">
           <div class="field">
             <label>${this._t('outerShadowBlur')}</label>
-            <input type="number" id="gauge${index}_outer_shadow_blur" value="${gauge.outer_shadow_blur || 30}" min="0" max="100">
+            <input type="number" id="gauge${index}_outer_shadow_blur" value="${esc(gauge.outer_shadow_blur || 30)}" min="0" max="100">
           </div>
           <div class="field">
             <label>${this._t('outerShadowSpread')}</label>
-            <input type="number" id="gauge${index}_outer_shadow_spread" value="${gauge.outer_shadow_spread || 15}" min="0" max="100">
+            <input type="number" id="gauge${index}_outer_shadow_spread" value="${esc(gauge.outer_shadow_spread || 15)}" min="0" max="100">
           </div>
         </div>
 
@@ -900,9 +951,9 @@ class DualGaugeCardEditor extends HTMLElement {
           <div class="severity-list" id="gauge${index}_severity_list">
             ${severity.map((s, i) => `
               <div class="severity-item" data-index="${i}">
-                <input type="color" value="${s.color}" data-field="color">
-                <input type="text" value="${s.color}" placeholder="#4caf50" data-field="color_text" style="width: 80px;">
-                <input type="number" value="${s.value}" placeholder="Value" data-field="value" min="0">
+                <input type="color" value="${esc(s.color)}" data-field="color">
+                <input type="text" value="${esc(s.color)}" placeholder="#4caf50" data-field="color_text" style="width: 80px;">
+                <input type="number" value="${esc(s.value)}" placeholder="Value" data-field="value" min="0">
                 <button class="remove-btn" data-action="remove-severity" data-gauge="${index}" data-item="${i}">×</button>
               </div>
             `).join('')}
@@ -915,7 +966,7 @@ class DualGaugeCardEditor extends HTMLElement {
           <div class="row">
             <div class="field">
               <label>${this._t('markersRadius')}</label>
-              <input type="number" id="gauge${index}_markers_radius" value="${gauge.markers_radius !== undefined ? gauge.markers_radius : ''}" placeholder="Auto" min="10" max="300" step="1">
+              <input type="number" id="gauge${index}_markers_radius" value="${esc(gauge.markers_radius !== undefined ? gauge.markers_radius : '')}" placeholder="Auto" min="10" max="300" step="1">
             </div>
             <div class="field checkbox">
               <input type="checkbox" id="gauge${index}_markers_inside" ${gauge.markers_inside !== false ? 'checked' : ''}>
@@ -925,9 +976,9 @@ class DualGaugeCardEditor extends HTMLElement {
           <div class="markers-list" id="gauge${index}_markers_list">
             ${markers.map((m, i) => `
               <div class="marker-item" data-index="${i}">
-                <input type="number" value="${m.value}" placeholder="Value" data-field="value" step="any">
-                <input type="color" value="${m.color || '#ffffff'}" data-field="color">
-                <input type="text" value="${m.label || ''}" placeholder="Label" data-field="label">
+                <input type="number" value="${esc(m.value)}" placeholder="Value" data-field="value" step="any">
+                <input type="color" value="${esc(m.color || '#ffffff')}" data-field="color">
+                <input type="text" value="${esc(m.label || '')}" placeholder="Label" data-field="label">
                 <button class="remove-btn" data-action="remove-marker" data-gauge="${index}" data-item="${i}">×</button>
               </div>
             `).join('')}
@@ -940,10 +991,10 @@ class DualGaugeCardEditor extends HTMLElement {
           <div class="zones-list" id="gauge${index}_zones_list">
             ${zones.map((z, i) => `
               <div class="zone-item" data-index="${i}">
-                <input type="number" value="${z.from}" placeholder="From" data-field="from" step="any">
-                <input type="number" value="${z.to}" placeholder="To" data-field="to" step="any">
-                <input type="color" value="${z.color || '#2196f3'}" data-field="color">
-                <input type="number" value="${z.opacity !== undefined ? z.opacity : 0.3}" placeholder="Opacity" data-field="opacity" min="0" max="1" step="0.1">
+                <input type="number" value="${esc(z.from)}" placeholder="From" data-field="from" step="any">
+                <input type="number" value="${esc(z.to)}" placeholder="To" data-field="to" step="any">
+                <input type="color" value="${esc(z.color || '#2196f3')}" data-field="color">
+                <input type="number" value="${esc(z.opacity !== undefined ? z.opacity : 0.3)}" placeholder="Opacity" data-field="opacity" min="0" max="1" step="0.1">
                 <button class="remove-btn" data-action="remove-zone" data-gauge="${index}" data-item="${i}">×</button>
               </div>
             `).join('')}
@@ -957,11 +1008,11 @@ class DualGaugeCardEditor extends HTMLElement {
           <div class="row">
             <div class="field">
               <label>${this._t('valueFont')}</label>
-              <input type="text" id="gauge${index}_value_font_family" value="${gauge.value_font_family || ''}" placeholder="inherit">
+              <input type="text" id="gauge${index}_value_font_family" value="${esc(gauge.value_font_family || '')}" placeholder="inherit">
             </div>
             <div class="field">
               <label>${this._t('valueSize')}</label>
-              <input type="text" id="gauge${index}_value_font_size" value="${gauge.value_font_size || ''}" placeholder="${index === 0 ? '24px' : '18px'}">
+              <input type="text" id="gauge${index}_value_font_size" value="${esc(gauge.value_font_size || '')}" placeholder="${index === 0 ? '24px' : '18px'}">
             </div>
             <div class="field">
               <label>${this._t('valueWeight')}</label>
@@ -987,17 +1038,17 @@ class DualGaugeCardEditor extends HTMLElement {
             <div class="field">
               <label>${this._t('valueColor')}</label>
               <div class="color-row">
-                <input type="color" id="gauge${index}_value_font_color" value="${gauge.value_font_color || '#ffffff'}" data-field="color">
-                <input type="text" id="gauge${index}_value_font_color_text" value="${gauge.value_font_color || ''}" placeholder="Auto" data-field="color_text">
+                <input type="color" id="gauge${index}_value_font_color" value="${esc(gauge.value_font_color || '#ffffff')}" data-field="color">
+                <input type="text" id="gauge${index}_value_font_color_text" value="${esc(gauge.value_font_color || '')}" placeholder="Auto" data-field="color_text">
               </div>
             </div>
             <div class="field">
               <label>${this._t('unitFont')}</label>
-              <input type="text" id="gauge${index}_unit_font_family" value="${gauge.unit_font_family || ''}" placeholder="inherit">
+              <input type="text" id="gauge${index}_unit_font_family" value="${esc(gauge.unit_font_family || '')}" placeholder="inherit">
             </div>
             <div class="field">
               <label>${this._t('unitSize')}</label>
-              <input type="text" id="gauge${index}_unit_font_size" value="${gauge.unit_font_size || ''}" placeholder="${index === 0 ? '14px' : '12px'}">
+              <input type="text" id="gauge${index}_unit_font_size" value="${esc(gauge.unit_font_size || '')}" placeholder="${index === 0 ? '14px' : '12px'}">
             </div>
           </div>
 
@@ -1023,8 +1074,8 @@ class DualGaugeCardEditor extends HTMLElement {
             <div class="field">
               <label>${this._t('unitColor')}</label>
               <div class="color-row">
-                <input type="color" id="gauge${index}_unit_font_color" value="${gauge.unit_font_color || '#dddddd'}" data-field="color">
-                <input type="text" id="gauge${index}_unit_font_color_text" value="${gauge.unit_font_color || ''}" placeholder="Auto" data-field="color_text">
+                <input type="color" id="gauge${index}_unit_font_color" value="${esc(gauge.unit_font_color || '#dddddd')}" data-field="color">
+                <input type="text" id="gauge${index}_unit_font_color_text" value="${esc(gauge.unit_font_color || '')}" placeholder="Auto" data-field="color_text">
               </div>
             </div>
           </div>
@@ -1235,6 +1286,8 @@ class DualGaugeCardEditor extends HTMLElement {
       this._config.gauges[i].decimals = getInputValue(`gauge${i}_decimals`) ?? this._config.gauges[i].decimals ?? 1;
       this._config.gauges[i].leds_count = getInputValue(`gauge${i}_leds_count`) ?? this._config.gauges[i].leds_count ?? (i === 0 ? 80 : 100);
       this._config.gauges[i].led_size = getInputValue(`gauge${i}_led_size`) ?? this._config.gauges[i].led_size ?? (i === 0 ? 6 : 8);
+      this._config.gauges[i].start_angle = getInputValue(`gauge${i}_start_angle`) ?? this._config.gauges[i].start_angle ?? 0;
+      this._config.gauges[i].arc_length = getInputValue(`gauge${i}_arc_length`) ?? this._config.gauges[i].arc_length ?? 360;
       this._config.gauges[i].markers_radius = getInputValue(`gauge${i}_markers_radius`) ?? this._config.gauges[i].markers_radius ?? undefined;
       this._config.gauges[i].markers_inside = getInputValue(`gauge${i}_markers_inside`) ?? this._config.gauges[i].markers_inside ?? true;
       this._config.gauges[i].theme = getInputValue(`gauge${i}_theme`) ?? this._config.gauges[i].theme ?? 'default';
@@ -1296,7 +1349,10 @@ class DualGaugeCardEditor extends HTMLElement {
       return el.value;
     };
 
+    // Spread the previous config first so keys the editor does not manage (view_layout,
+    // grid_options, visibility, ...) survive a round-trip through the visual editor.
     const newConfig = {
+      ...this._config,
       type: 'custom:dual-gauge-card',
       name: getValue('name') || '',
       gauge_size: getValue('gauge_size') || 200,
@@ -1312,42 +1368,33 @@ class DualGaugeCardEditor extends HTMLElement {
       gauges: [0, 1].map(idx => this._getGaugeConfig(idx))
     };
 
-    // Add optional parameters only if defined
-    const customBg = getValue('custom_background_text');
-    if (customBg) newConfig.custom_background = customBg;
-    
-    const customGaugeBg = getValue('custom_gauge_background_text');
-    if (customGaugeBg) newConfig.custom_gauge_background = customGaugeBg;
-    
-    const customCenterBg = getValue('custom_center_background_text');
-    if (customCenterBg) newConfig.custom_center_background = customCenterBg;
-    
-    const customTextColor = getValue('custom_text_color_text');
-    if (customTextColor) newConfig.custom_text_color = customTextColor;
-    
-    const customSecondaryText = getValue('custom_secondary_text_color_text');
-    if (customSecondaryText) newConfig.custom_secondary_text_color = customSecondaryText;
+    // Optional parameters: keep them out of the YAML when the field is empty, and drop any
+    // previous value so clearing a field in the editor really clears it
+    const setOptional = (key, value) => {
+      if (value) {
+        newConfig[key] = value;
+      } else {
+        delete newConfig[key];
+      }
+    };
+
+    setOptional('custom_background', getValue('custom_background_text'));
+    setOptional('custom_gauge_background', getValue('custom_gauge_background_text'));
+    setOptional('custom_center_background', getValue('custom_center_background_text'));
+    setOptional('custom_text_color', getValue('custom_text_color_text'));
+    setOptional('custom_secondary_text_color', getValue('custom_secondary_text_color_text'));
 
     // Title typography
-    const titleFontSize = getValue('title_font_size');
-    if (titleFontSize) newConfig.title_font_size = titleFontSize;
-    
-    const titleFontFamily = getValue('title_font_family');
-    if (titleFontFamily) newConfig.title_font_family = titleFontFamily;
-    
-    const titleFontWeight = getValue('title_font_weight');
-    if (titleFontWeight) newConfig.title_font_weight = titleFontWeight;
-    
-    const titleFontColor = getValue('title_font_color_text');
-    if (titleFontColor) newConfig.title_font_color = titleFontColor;
-    
-    const cardBackground = getValue('card_background');
-    if (cardBackground) newConfig.card_background = cardBackground;
+    setOptional('title_font_size', getValue('title_font_size'));
+    setOptional('title_font_family', getValue('title_font_family'));
+    setOptional('title_font_weight', getValue('title_font_weight'));
+    setOptional('title_font_color', getValue('title_font_color_text'));
+    setOptional('card_background', getValue('card_background'));
 
     // Transparency
-    if (getValue('transparent_card_background')) newConfig.transparent_card_background = true;
-    if (getValue('transparent_gauge_background')) newConfig.transparent_gauge_background = true;
-    if (getValue('transparent_center_background')) newConfig.transparent_center_background = true;
+    setOptional('transparent_card_background', getValue('transparent_card_background'));
+    setOptional('transparent_gauge_background', getValue('transparent_gauge_background'));
+    setOptional('transparent_center_background', getValue('transparent_center_background'));
 
     this._config = newConfig;
     this._fireConfigChanged();
@@ -1365,7 +1412,9 @@ class DualGaugeCardEditor extends HTMLElement {
       return el.value;
     };
 
+    // Keep per-gauge keys the editor does not manage (custom theme colors, tap actions, ...)
     const config = {
+      ...(this._config?.gauges?.[index] || {}),
       entity: getValue(`gauge${index}_entity`) || '',
       min: getValue(`gauge${index}_min`) !== undefined ? getValue(`gauge${index}_min`) : 0,
       max: getValue(`gauge${index}_max`) !== undefined ? getValue(`gauge${index}_max`) : 100,
@@ -1373,6 +1422,8 @@ class DualGaugeCardEditor extends HTMLElement {
       decimals: getValue(`gauge${index}_decimals`) !== undefined ? getValue(`gauge${index}_decimals`) : 1,
       leds_count: getValue(`gauge${index}_leds_count`) !== undefined ? getValue(`gauge${index}_leds_count`) : (index === 0 ? 80 : 100),
       led_size: getValue(`gauge${index}_led_size`) !== undefined ? getValue(`gauge${index}_led_size`) : (index === 0 ? 6 : 8),
+      start_angle: getValue(`gauge${index}_start_angle`) !== undefined ? getValue(`gauge${index}_start_angle`) : 0,
+      arc_length: getValue(`gauge${index}_arc_length`) !== undefined ? getValue(`gauge${index}_arc_length`) : 360,
       markers_radius: getValue(`gauge${index}_markers_radius`) !== undefined ? getValue(`gauge${index}_markers_radius`) : undefined,
       markers_inside: getValue(`gauge${index}_markers_inside`) !== false,
       theme: getValue(`gauge${index}_theme`) || 'default',
@@ -1387,6 +1438,11 @@ class DualGaugeCardEditor extends HTMLElement {
       outer_shadow_blur: getValue(`gauge${index}_outer_shadow_blur`) || 30,
       outer_shadow_spread: getValue(`gauge${index}_outer_shadow_spread`) || 15
     };
+
+    // markers_radius is optional: an empty field means "auto"
+    if (config.markers_radius === undefined) {
+      delete config.markers_radius;
+    }
 
     // Get severity thresholds
     const severityList = this.shadowRoot.getElementById(`gauge${index}_severity_list`);
@@ -1451,9 +1507,11 @@ class DualGaugeCardEditor extends HTMLElement {
   }
 
   _fireConfigChanged() {
-    const event = new Event('config-changed', { bubbles: true, composed: true });
-    event.detail = { config: this._config };
-    this.dispatchEvent(event);
+    this.dispatchEvent(new CustomEvent('config-changed', {
+      detail: { config: this._config },
+      bubbles: true,
+      composed: true
+    }));
   }
 }
 

--- a/dual-gauge-card.js
+++ b/dual-gauge-card.js
@@ -1,6 +1,6 @@
 /**
  * Dual Gauge Card - Standalone Version (Non-compiled)
- * Version: 1.2.0
+ * Version: 1.4.0
  * 
  * Ce fichier est le point d'entrée principal qui charge :
  * - Le core de la carte (inline ci-dessous)
@@ -11,7 +11,7 @@
 // CONFIGURATION AND THEMES
 // ============================================================================
 
-const CARD_VERSION = '1.3.0';
+const CARD_VERSION = '1.4.0';
 
 const themes = {
   default: {
@@ -113,6 +113,56 @@ function optimizeLEDs(configuredCount) {
   return configuredCount || 100;
 }
 
+const DEFAULT_START_ANGLE = 0;
+const DEFAULT_ARC_LENGTH = 360;
+
+/**
+ * Read the arc geometry of a gauge (start offset and arc length, in degrees)
+ * @param {Object} gaugeConfig - Configuration of a single gauge
+ * @returns {{startAngle: number, arcLength: number}} Geometry, 0° = top (12 o'clock), clockwise
+ */
+function getArcGeometry(gaugeConfig) {
+  const startAngle = Number(gaugeConfig?.start_angle);
+  const arcLength = Number(gaugeConfig?.arc_length);
+
+  return {
+    startAngle: Number.isFinite(startAngle) ? startAngle : DEFAULT_START_ANGLE,
+    arcLength: Number.isFinite(arcLength) && arcLength > 0
+      ? Math.min(arcLength, 360)
+      : DEFAULT_ARC_LENGTH
+  };
+}
+
+/**
+ * Reference point used by the bidirectional mode (adaptive zero)
+ * @param {number} min - Minimum value
+ * @param {number} max - Maximum value
+ * @returns {number} Zero when the range crosses it, the midpoint otherwise
+ */
+function getReferencePoint(min, max) {
+  return (min <= 0 && max >= 0) ? 0 : (min + max) / 2;
+}
+
+/**
+ * Position of the bidirectional reference point inside the arc, as a 0-1 fraction
+ *
+ * On a full circle the reference stays at the start of the arc and the lower side wraps
+ * around the seam (historical behaviour). On a partial arc there is nothing to wrap into,
+ * so the reference sits proportionally inside the arc and both sides stay visible.
+ * @param {number} min - Minimum value
+ * @param {number} max - Maximum value
+ * @param {number} arcLength - Arc length in degrees
+ * @returns {number} Fraction of the arc between its start and the reference point
+ */
+function getBidirectionalOrigin(min, max, arcLength) {
+  if (arcLength >= 360) return 0;
+
+  const totalRange = max - min;
+  if (totalRange <= 0) return 0;
+
+  return (getReferencePoint(min, max) - min) / totalRange;
+}
+
 /**
  * Calculate bidirectional LED activation
  * @param {number} value - Current value
@@ -120,9 +170,10 @@ function optimizeLEDs(configuredCount) {
  * @param {number} max - Maximum value
  * @param {number} ledsCount - Total number of LEDs
  * @param {boolean} bidirectional - Enable bidirectional mode
- * @returns {Object} Object with activeLeds count and direction ('positive', 'negative', or 'unidirectional')
+ * @param {number} arcLength - Arc length in degrees (360 = full circle)
+ * @returns {Object} Object with activeLeds count, originIndex and direction ('positive', 'negative', or 'unidirectional')
  */
-function calculateBidirectionalLeds(value, min, max, ledsCount, bidirectional) {
+function calculateBidirectionalLeds(value, min, max, ledsCount, bidirectional, arcLength = DEFAULT_ARC_LENGTH) {
   // Calculate full-range normalized value for severity colors (always needed)
   const fullRangeNormalized = ((value - min) / (max - min)) * 100;
 
@@ -131,17 +182,20 @@ function calculateBidirectionalLeds(value, min, max, ledsCount, bidirectional) {
     const activeLeds = Math.round((fullRangeNormalized / 100) * ledsCount);
     return {
       activeLeds,
+      originIndex: 0,
       direction: 'unidirectional',
       normalizedValue: fullRangeNormalized
     };
   }
 
-  // Bidirectional mode: reference point is at the top (LED index 0)
+  // Bidirectional mode: reference point is at the origin LED (start of the arc on a full
+  // circle, proportionally inside the arc otherwise)
   // Values above reference go clockwise (to the right)
   // Values below reference go counter-clockwise (to the left)
 
   // Determine reference point (adaptive zero)
-  const referencePoint = (min <= 0 && max >= 0) ? 0 : (min + max) / 2;
+  const referencePoint = getReferencePoint(min, max);
+  const originIndex = Math.round(getBidirectionalOrigin(min, max, arcLength) * ledsCount);
 
   // Calculate range sizes on each side of reference
   const totalRange = max - min;
@@ -161,6 +215,7 @@ function calculateBidirectionalLeds(value, min, max, ledsCount, bidirectional) {
 
     return {
       activeLeds,
+      originIndex,
       direction: 'positive',
       normalizedValue: fullRangeNormalized  // Use full-range for severity colors
     };
@@ -173,6 +228,7 @@ function calculateBidirectionalLeds(value, min, max, ledsCount, bidirectional) {
 
     return {
       activeLeds,
+      originIndex,
       direction: 'negative',
       normalizedValue: fullRangeNormalized  // Use full-range for severity colors
     };
@@ -185,39 +241,44 @@ function calculateBidirectionalLeds(value, min, max, ledsCount, bidirectional) {
  * @param {number} min - Minimum range value
  * @param {number} max - Maximum range value
  * @param {boolean} bidirectional - Whether bidirectional mode is enabled
- * @returns {number} Angle in degrees (0-360)
+ * @param {number} startAngle - Offset of the start of the arc in degrees (0 = top)
+ * @param {number} arcLength - Arc length in degrees (360 = full circle)
+ * @returns {number} Angle in degrees, relative to the top and going clockwise
  */
-function valueToAngle(value, min, max, bidirectional) {
+function valueToAngle(value, min, max, bidirectional, startAngle = DEFAULT_START_ANGLE, arcLength = DEFAULT_ARC_LENGTH) {
   if (!bidirectional) {
-    // Unidirectional mode: simple linear mapping
+    // Unidirectional mode: simple linear mapping over the arc
     const percentage = ((value - min) / (max - min)) * 100;
-    return (percentage / 100) * 360;
+    return startAngle + (percentage / 100) * arcLength;
   }
 
   // Bidirectional mode: proportional allocation with adaptive reference point
 
   // Determine reference point (adaptive zero)
-  const referencePoint = (min <= 0 && max >= 0) ? 0 : (min + max) / 2;
+  const referencePoint = getReferencePoint(min, max);
 
   // Calculate range sizes on each side of reference
   const totalRange = max - min;
   const lowerRange = referencePoint - min;  // Size from min to reference
   const upperRange = max - referencePoint;  // Size from reference to max
 
-  // Calculate proportional angle allocation (total 360°)
+  // Calculate proportional angle allocation over the arc
   const lowerProportion = lowerRange / totalRange;
   const upperProportion = upperRange / totalRange;
-  const maxLowerAngle = lowerProportion * 360;  // Degrees allocated to lower side
-  const maxUpperAngle = upperProportion * 360;  // Degrees allocated to upper side
+  const maxLowerAngle = lowerProportion * arcLength;  // Degrees allocated to lower side
+  const maxUpperAngle = upperProportion * arcLength;  // Degrees allocated to upper side
+
+  // Angle of the reference point itself
+  const originAngle = startAngle + getBidirectionalOrigin(min, max, arcLength) * arcLength;
 
   if (value >= referencePoint) {
-    // Upper values: go clockwise from top (0° to maxUpperAngle)
+    // Upper values: go clockwise from the reference point
     const percentage = upperRange > 0 ? ((value - referencePoint) / upperRange) * 100 : 0;
-    return (percentage / 100) * maxUpperAngle;
+    return originAngle + (percentage / 100) * maxUpperAngle;
   } else {
-    // Lower values: go counter-clockwise from top (360° to 360° - maxLowerAngle)
+    // Lower values: go counter-clockwise from the reference point
     const percentage = lowerRange > 0 ? ((referencePoint - value) / lowerRange) * 100 : 0;
-    return 360 - ((percentage / 100) * maxLowerAngle);
+    return originAngle - ((percentage / 100) * maxLowerAngle);
   }
 }
 
@@ -451,10 +512,16 @@ const stylesCSS = `
 // RENDERER
 // ============================================================================
 
-function generateLedsHTML(ledsCount, radius, ledSize, prefix = '') {
+function generateLedsHTML(ledsCount, radius, ledSize, prefix = '', startAngle = DEFAULT_START_ANGLE, arcLength = DEFAULT_ARC_LENGTH) {
+  // On a full circle the last LED must not land on the first one, so the step divides the
+  // arc by the LED count. On a partial arc both ends are visible and must carry a LED.
+  const step = arcLength >= 360
+    ? arcLength / ledsCount
+    : arcLength / Math.max(ledsCount - 1, 1);
+
   const leds = [];
   for (let i = 0; i < ledsCount; i++) {
-    const angle = (i / ledsCount) * 360 - 90;
+    const angle = startAngle + i * step - 90;
     const translate = radius - ledSize;
     leds.push(`<div class="led" id="led-${prefix}${prefix ? '-' : ''}${i}" style="transform: rotate(${angle}deg) translate(${translate}px);"></div>`);
   }
@@ -481,6 +548,9 @@ function renderDual(context) {
     : (innerGaugeSize / 2);
   const ledSize1 = config1.led_size || 6;
   const ledSize2 = config2.led_size || 8;
+
+  const arc1 = getArcGeometry(config1);
+  const arc2 = getArcGeometry(config2);
 
   // Déterminer le thème global de la carte (utilise le thème de la première gauge par défaut)
   const globalTheme = context.config.card_theme ? getTheme(context.config.card_theme, context.config) : theme1;
@@ -596,8 +666,8 @@ function renderDual(context) {
         <div class="outer-shadow" id="outer-shadow-outer"></div>
         <div class="center-shadow" id="center-shadow-inner"></div>
         <div class="center-shadow" id="center-shadow-outer"></div>
-        ${generateLedsHTML(ledsCount2, outerGaugeSize / 2, ledSize2, 'outer')}
-        ${generateLedsHTML(ledsCount1, innerGaugeRadius, ledSize1, 'inner')}
+        ${generateLedsHTML(ledsCount2, outerGaugeSize / 2, ledSize2, 'outer', arc2.startAngle, arc2.arcLength)}
+        ${generateLedsHTML(ledsCount1, innerGaugeRadius, ledSize1, 'inner', arc1.startAngle, arc1.arcLength)}
         <div class="center dual-center" style="background: ${globalTheme.centerBackground}">
           <div class="value-group" id="group-inner">
             <div class="value" id="value-inner">0</div>
@@ -637,6 +707,9 @@ function addMarkersAndZones(context) {
   const config1 = context.config.gauges[0];
   const config2 = context.config.gauges[1];
 
+  const arc1 = getArcGeometry(config1);
+  const arc2 = getArcGeometry(config2);
+
   // Ajouter markers pour la gauge interne (gauge 0)
   if (config1.markers) {
     const min1 = config1.min || 0;
@@ -648,7 +721,7 @@ function addMarkersAndZones(context) {
     const markersInside1 = config1.markers_inside !== false;
 
     config1.markers.forEach(marker => {
-      const angle = valueToAngle(marker.value, min1, max1, config1.bidirectional || false);
+      const angle = valueToAngle(marker.value, min1, max1, config1.bidirectional || false, arc1.startAngle, arc1.arcLength);
 
       // Calcul cartésien pour positionnement précis
       const angleRad = (angle - 90) * Math.PI / 180;
@@ -707,7 +780,7 @@ function addMarkersAndZones(context) {
     const markersInside2 = config2.markers_inside !== false;
 
     config2.markers.forEach(marker => {
-      const angle = valueToAngle(marker.value, min2, max2, config2.bidirectional || false);
+      const angle = valueToAngle(marker.value, min2, max2, config2.bidirectional || false, arc2.startAngle, arc2.arcLength);
 
       // Calcul cartésien pour positionnement précis
       const angleRad = (angle - 90) * Math.PI / 180;
@@ -762,8 +835,8 @@ function addMarkersAndZones(context) {
     const svgSize = (innerGaugeRadius + 10) * 2;
 
     config1.zones.forEach(zone => {
-      const startAngle = valueToAngle(zone.from, min1, max1, config1.bidirectional || false);
-      const endAngle = valueToAngle(zone.to, min1, max1, config1.bidirectional || false);
+      const startAngle = valueToAngle(zone.from, min1, max1, config1.bidirectional || false, arc1.startAngle, arc1.arcLength);
+      const endAngle = valueToAngle(zone.to, min1, max1, config1.bidirectional || false, arc1.startAngle, arc1.arcLength);
 
       // Calculate arc angle (handle wrapping around 0°/360°)
       let arcAngle = endAngle - startAngle;
@@ -812,8 +885,8 @@ function addMarkersAndZones(context) {
     const max2 = config2.max || 100;
 
     config2.zones.forEach(zone => {
-      const startAngle = valueToAngle(zone.from, min2, max2, config2.bidirectional || false);
-      const endAngle = valueToAngle(zone.to, min2, max2, config2.bidirectional || false);
+      const startAngle = valueToAngle(zone.from, min2, max2, config2.bidirectional || false, arc2.startAngle, arc2.arcLength);
+      const endAngle = valueToAngle(zone.to, min2, max2, config2.bidirectional || false, arc2.startAngle, arc2.arcLength);
 
       // Calculate arc angle (handle wrapping around 0°/360°)
       let arcAngle = endAngle - startAngle;
@@ -867,7 +940,8 @@ function updateLedsDual(context, value, ledsCount, prefix, gaugeConfig) {
   // Convert normalized value (0-100%) back to real value for bidirectional calculation
   const realValue = min + (value / 100) * (max - min);
   const bidirectional = gaugeConfig.bidirectional || false;
-  const ledInfo = calculateBidirectionalLeds(realValue, min, max, ledsCount, bidirectional);
+  const { arcLength } = getArcGeometry(gaugeConfig);
+  const ledInfo = calculateBidirectionalLeds(realValue, min, max, ledsCount, bidirectional, arcLength);
 
   const color = getLedColor(ledInfo.normalizedValue, gaugeConfig.severity, min, max);
 
@@ -886,15 +960,17 @@ function updateLedsDual(context, value, ledsCount, prefix, gaugeConfig) {
     let isActive = false;
 
     if (ledInfo.direction === 'unidirectional') {
-      // Standard unidirectional mode: activate from LED 0 onwards
+      // Standard unidirectional mode: activate from the first LED of the arc onwards
       isActive = i < ledInfo.activeLeds;
     } else if (ledInfo.direction === 'positive') {
-      // Bidirectional positive: activate clockwise from LED 0
-      isActive = i < ledInfo.activeLeds;
+      // Bidirectional positive: activate clockwise from the reference LED
+      isActive = i >= ledInfo.originIndex && i < ledInfo.originIndex + ledInfo.activeLeds;
     } else if (ledInfo.direction === 'negative') {
-      // Bidirectional negative: activate counter-clockwise from LED 0
-      // LED 0 is the zero point (12h) and must be included, then LEDs go backwards (99, 98, 97...)
-      isActive = (i === 0) || (i > (ledsCount - ledInfo.activeLeds));
+      // Bidirectional negative: activate counter-clockwise from the reference LED, which is
+      // always lit. On a full circle the reference is LED 0 and the lower side wraps around
+      // the end of the ring (99, 98, 97...).
+      const distanceFromOrigin = (ledInfo.originIndex - i + ledsCount) % ledsCount;
+      isActive = distanceFromOrigin < Math.max(ledInfo.activeLeds, 1);
     }
 
     if (isActive) {
@@ -1070,24 +1146,30 @@ function parseDualConfig(config) {
     debounce_updates: config.debounce_updates || false,
     hide_shadows: config.hide_shadows || false,
 
-    gauges: config.gauges.map(gaugeConfig => ({
-      ...gaugeConfig,
-      min: gaugeConfig.min !== undefined ? gaugeConfig.min : 0,
-      max: gaugeConfig.max !== undefined ? gaugeConfig.max : 100,
-      leds_count: gaugeConfig.leds_count || 100,
-      led_size: gaugeConfig.led_size || 8,
-      decimals: gaugeConfig.decimals !== undefined ? gaugeConfig.decimals : 1,
-      smooth_transitions: gaugeConfig.smooth_transitions !== false,
-      animation_duration: gaugeConfig.animation_duration || 800,
-      severity: gaugeConfig.severity || [
-        { color: '#4caf50', value: 0 },
-        { color: '#ff9800', value: 50 },
-        { color: '#f44336', value: 75 }
-      ],
-      theme: gaugeConfig.theme || 'default',
-      hide_inactive_leds: gaugeConfig.hide_inactive_leds || false,
-      bidirectional: gaugeConfig.bidirectional || false
-    }))
+    gauges: config.gauges.map(gaugeConfig => {
+      const arc = getArcGeometry(gaugeConfig);
+
+      return {
+        ...gaugeConfig,
+        min: gaugeConfig.min !== undefined ? gaugeConfig.min : 0,
+        max: gaugeConfig.max !== undefined ? gaugeConfig.max : 100,
+        leds_count: gaugeConfig.leds_count || 100,
+        led_size: gaugeConfig.led_size || 8,
+        decimals: gaugeConfig.decimals !== undefined ? gaugeConfig.decimals : 1,
+        smooth_transitions: gaugeConfig.smooth_transitions !== false,
+        animation_duration: gaugeConfig.animation_duration || 800,
+        severity: gaugeConfig.severity || [
+          { color: '#4caf50', value: 0 },
+          { color: '#ff9800', value: 50 },
+          { color: '#f44336', value: 75 }
+        ],
+        theme: gaugeConfig.theme || 'default',
+        hide_inactive_leds: gaugeConfig.hide_inactive_leds || false,
+        bidirectional: gaugeConfig.bidirectional || false,
+        start_angle: arc.startAngle,
+        arc_length: arc.arcLength
+      };
+    })
   };
 
   return parsedConfig;
@@ -1108,10 +1190,12 @@ class DualGaugeCard extends HTMLElement {
     this.animationInterval1 = null;
     this.animationInterval2 = null;
 
-    this.attachShadow({ mode: "open" });
+    // Home Assistant calls setConfig() again whenever the configuration changes (live
+    // preview in the editor), and attachShadow() throws on an element that already has one.
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: "open" });
+    }
     renderDual(this);
-
-    this._updateDualGauge = () => updateDualGauge(this);
 
     this._updateDualGauge = () => updateDualGauge(this);
 
@@ -1131,13 +1215,16 @@ class DualGaugeCard extends HTMLElement {
       });
     }
 
-    if (this.config.power_save_mode) {
+    // setConfig() can run several times on the same element, only observe once
+    if (this.config.power_save_mode && !this._visibilityObserver) {
       this._setupVisibilityObserver();
     }
   }
 
   set hass(hass) {
     this._hass = hass;
+
+    if (!this.config) return;
 
     if (this.config.power_save_mode && !this.isVisible) return;
 
@@ -1155,7 +1242,7 @@ class DualGaugeCard extends HTMLElement {
   }
 
   _setupVisibilityObserver() {
-    const observer = new IntersectionObserver(
+    this._visibilityObserver = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
           this.isVisible = entry.isIntersecting;
@@ -1167,15 +1254,17 @@ class DualGaugeCard extends HTMLElement {
       { threshold: 0.1 }
     );
 
-    observer.observe(this);
+    this._visibilityObserver.observe(this);
   }
 
   _showEntityHistory(entityId) {
     if (!entityId || !this._hass) return;
 
-    const event = new Event("hass-more-info", { bubbles: true, composed: true });
-    event.detail = { entityId };
-    this.dispatchEvent(event);
+    this.dispatchEvent(new CustomEvent("hass-more-info", {
+      detail: { entityId },
+      bubbles: true,
+      composed: true
+    }));
   }
 
   getCardSize() {

--- a/dual-gauge-example.yaml
+++ b/dual-gauge-example.yaml
@@ -149,3 +149,50 @@ gauges:
 
 hide_shadows: false
 title_position: top
+
+---
+# EXEMPLE AVEC ARC PARTIEL
+# start_angle décale le point de départ (0° = haut, sens horaire)
+# arc_length définit l'ouverture de la jauge en degrés (360° = cercle complet)
+
+type: custom:dual-gauge-card
+name: "Chaudière"
+gauge_size: 220
+inner_gauge_size: 140
+title_position: bottom
+
+gauges:
+  # Gauge intérieure : arc de 270° ouvert en bas (style tableau de bord)
+  - entity: sensor.temperature_depart
+    unit: "°C"
+    min: 0
+    max: 90
+    decimals: 0
+    start_angle: -135   # Départ en bas à gauche
+    arc_length: 270     # Fin en bas à droite
+    leds_count: 80
+    led_size: 6
+    markers:
+      - value: 45
+        color: "#ffffff"
+        label: "45°"
+
+  # Gauge extérieure : même géométrie pour rester alignée
+  - entity: sensor.temperature_retour
+    unit: "°C"
+    min: 0
+    max: 90
+    decimals: 0
+    start_angle: -135
+    arc_length: 270
+    leds_count: 100
+    led_size: 8
+    zones:
+      - from: 0
+        to: 30
+        color: "#0288d1"
+        opacity: 0.4
+      - from: 70
+        to: 90
+        color: "#f44336"
+        opacity: 0.4


### PR DESCRIPTION
Each gauge can now be rotated and shortened independently:

- `start_angle` (degrees, default 0) offsets the starting point of the
  gauge, 0 = top (12 o'clock), positive values rotate clockwise
- `arc_length` (degrees, default 360) sets the angular span, so a gauge
  can be a full circle, a 270 degrees dashboard arc or a half circle

Both options are exposed in the visual editor in a new "Arc Geometry"
section, and are applied to the LEDs, the markers and the zones so they
stay aligned. On a partial arc both ends carry a LED so min sits exactly
at the start of the arc and max at its end; the full-circle LED
distribution is unchanged.

In bidirectional mode the reference point still sits at the start of the
arc on a full circle. On a partial arc there is nothing to wrap around,
so it is placed proportionally inside the arc and both sides stay
visible.

Also fixes a few Home Assistant compliance issues found while adding the
options:

- setConfig() ran attachShadow() unconditionally, so the second call
  (live preview in the editor) threw NotSupportedError
- config-changed and hass-more-info were plain Events with a detail
  property attached instead of CustomEvents
- the editor rebuilt the whole config on every change, dropping keys it
  does not manage (view_layout, grid_options, per-gauge tap_action, ...)
- clearing an optional field left the previous value in the YAML
- configuration values were injected in the editor markup without
  escaping, so a quote in a name or a label broke the form
- the entity dropdowns were rebuilt on every hass update

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C7rUR4pvbzisTbHHDXBnWp